### PR TITLE
General update

### DIFF
--- a/Control/Monad/Reader/CPS.hs
+++ b/Control/Monad/Reader/CPS.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Trustworthy, Rank2Types, FlexibleInstances, FlexibleContexts, MultiParamTypeClasses #-}
+{-# LANGUAGE Trustworthy, Rank2Types, FlexibleInstances, FlexibleContexts, MultiParamTypeClasses, UndecidableInstances #-}
 module Control.Monad.Reader.CPS (ReaderT(..)
     , runReaderT
     , mapReaderT
@@ -6,10 +6,13 @@ module Control.Monad.Reader.CPS (ReaderT(..)
     , runReader
     , module Control.Monad.Reader.Class) where
 import Control.Monad.Reader.Class
+import Control.Monad.State.Class
 import Control.Applicative
 import Control.Monad.Identity
 import Control.Monad.Trans
-import Unsafe.Coerce
+import Control.Monad.IO.Class
+import Control.Monad.Error.Class
+import Control.Monad.Writer.Class
 
 newtype ReaderT r m a = ReaderT { unReaderT :: forall b. r -> (a -> m b) -> m b }
 
@@ -29,14 +32,16 @@ instance Applicative (ReaderT r m) where
     {-# INLINABLE pure #-}
     mf <*> ma = ReaderT $ \r c -> unReaderT mf r $ \f -> unReaderT ma r (c . f)
     {-# INLINABLE (<*>) #-}
+    m *> n = ReaderT $ \r c -> unReaderT m r (\_ -> unReaderT n r c)
+    {-# INLINABLE (*>) #-}
 
 instance Monad (ReaderT r m) where
     return x = ReaderT $ \_ c -> c x
     {-# INLINABLE return #-}
     m >>= k = ReaderT $ \r c -> unReaderT m r (\a -> unReaderT (k a) r c)
     {-# INLINABLE (>>=) #-}
-    m >> n = ReaderT $ \r c -> unReaderT m r (\_ -> unReaderT n r c)
-    {-# INLINABLE (>>) #-}
+    (>>) = (*>)
+    {-# INLINE (>>) #-}
 
 instance MonadReader r (ReaderT r m) where
     ask = ReaderT $ \r c -> c r
@@ -46,12 +51,34 @@ instance MonadReader r (ReaderT r m) where
     reader f = ReaderT $ \r c -> c (f r)
     {-# INLINABLE reader #-}
 
+instance MonadIO m => MonadIO (ReaderT r m) where
+    liftIO = lift . liftIO
+    {-# INLINABLE liftIO #-}
+
+instance MonadState s m => MonadState s (ReaderT r m) where
+    get = lift get
+    {-# INLINABLE get #-}
+    put = lift . put
+    {-# INLINABLE put #-}
+
 instance MonadTrans (ReaderT r) where
     lift m = ReaderT $ const (m >>=)
     {-# INLINABLE lift #-}
 
+instance MonadError e m => MonadError e (ReaderT r m) where
+    throwError = lift . throwError
+    {-# INLINABLE throwError #-}
+
+    catchError m h = ReaderT $ \r c -> catchError (unReaderT m r return) (\e -> runReaderT (h e) r) >>= c
+    {-# INLINABLE catchError #-}
+
+instance MonadWriter w m => MonadWriter w (ReaderT r m) where
+    tell = lift . tell
+    listen m = ReaderT $ \r c -> listen (runReaderT m r) >>= c
+    pass m = ReaderT $ \r c -> pass (runReaderT m r) >>= c
+
 type Reader r = ReaderT r Identity
 
 runReader :: Reader r a -> r -> a
-runReader = asTypeOf unsafeCoerce ((runIdentity .) .) runReaderT
+runReader m r = runIdentity (runReaderT m r)
 {-# INLINE runReader #-}

--- a/Control/Monad/State/CPS.hs
+++ b/Control/Monad/State/CPS.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE Trustworthy, Rank2Types, FlexibleInstances, FlexibleContexts, MultiParamTypeClasses, BangPatterns #-}
+{-# LANGUAGE Trustworthy, Rank2Types, FlexibleInstances, FlexibleContexts, MultiParamTypeClasses, BangPatterns,
+      UndecidableInstances #-}
 module Control.Monad.State.CPS (StateT(..)
     , runStateT
     , evalStateT
@@ -13,7 +14,10 @@ import Control.Monad.State.Class
 import Control.Applicative
 import Control.Monad.Identity
 import Control.Monad.Trans
-import Unsafe.Coerce
+import Control.Monad.IO.Class
+import Control.Monad
+import Control.Monad.Cont.Class
+import Control.Monad.Reader.Class
 
 newtype StateT s m a = StateT { unStateT :: forall r. s -> (a -> s -> m r) -> m r }
 
@@ -30,7 +34,9 @@ execStateT m s = unStateT m s $ \_ s -> return s
 {-# INLINABLE execStateT #-}
 
 mapStateT :: (Monad m, Monad n) => (m (a, s) -> n (b, s)) -> StateT s m a -> StateT s n b
-mapStateT t m = StateT $ \s c -> t (unStateT m s (\a s -> return (a, s))) >>= \(b, s') -> c b s'
+-- This used to be implemented directly, but doing it this way produces identical
+-- Core and is considerably simpler.
+mapStateT t m = stateT $ \s -> t (runStateT m s)
 
 instance Functor (StateT s m) where
     fmap f m = StateT $ \s c -> unStateT m s (c . f)
@@ -41,13 +47,14 @@ instance Applicative (StateT s m) where
     {-# INLINABLE pure #-}
     mf <*> ma = StateT $ \s c -> unStateT mf s $ \f s' -> unStateT ma s' (c . f)
     {-# INLINABLE (<*>) #-}
+    m *> n = StateT $ \s c -> unStateT m s $ \_ s' -> unStateT n s' c
+    {-# INLINABLE (*>) #-}
 
 instance Monad (StateT s m) where
     return x = StateT $ \s c -> c x s
     m >>= k = StateT $ \s c -> unStateT m s $ \a s' -> unStateT (k a) s' c
     {-# INLINABLE (>>=) #-}
-    m >> n = StateT $ \s c -> unStateT m s $ \_ s' -> unStateT n s' c
-    {-# INLINABLE (>>) #-}
+    (>>) = (*>)
 
 instance MonadState s (StateT s m) where
     get = StateT $ \s c -> c s s
@@ -61,16 +68,38 @@ instance MonadTrans (StateT s) where
     lift m = StateT $ \s c -> m >>= \a -> c a s
     {-# INLINABLE lift #-}
 
+instance MonadIO m => MonadIO (StateT s m) where
+  liftIO = lift . liftIO
+
+instance MonadReader e m => MonadReader e (StateT s m) where
+  ask = lift ask
+
+  local f m = stateT $ \s -> local f (runStateT m s)
+
+instance MonadFix m => MonadFix (StateT s m) where
+  mfix f = stateT $ \s -> mfix $ \ ~(a, _) -> runStateT (f a) s
+
+instance MonadCont m => MonadCont (StateT s m) where
+  callCC f = stateT $ \s -> callCC $ \c -> runStateT (f (\a -> stateT $ \s' -> c (a, s'))) s
+
+-- A stricter version of 'state'. The latter uses the
+-- lazy 'uncurry' function for some reason.
+stateT :: Monad m => (s -> m (a, s)) -> StateT s m a
+stateT f = StateT $ \s c -> do
+  (a, s') <- f s
+  c a s'
+{-# INLINE stateT #-}
+
 type State s = StateT s Identity
 
 runState :: State s a -> s -> (a, s)
-runState = asTypeOf unsafeCoerce ((runIdentity .) .) runStateT
+runState m s = runIdentity $ runStateT m s
 {-# INLINE runState #-}
 
 evalState :: State s a -> s -> a
-evalState = asTypeOf unsafeCoerce ((runIdentity .) .) evalStateT
+evalState m s = runIdentity $ evalStateT m s
 {-# INLINE evalState #-}
 
 execState :: State s a -> s -> s
-execState = asTypeOf unsafeCoerce ((runIdentity .) .) execStateT
+execState m s = runIdentity $ execStateT m s
 {-# INLINE execState #-}

--- a/mtl-c.cabal
+++ b/mtl-c.cabal
@@ -19,4 +19,4 @@ source-repository head
 library
   exposed-modules:     Control.Monad.Reader.CPS, Control.Monad.Writer.CPS, Control.Monad.State.CPS
   -- other-modules:
-  build-depends:       base ==4.*, mtl ==2.*
+  build-depends:       base ==4.*, mtl ==2.*, transformers


### PR DESCRIPTION
* Add a slew of `mtl` instances. Most of these are either simple
  lifts or effectively translations through `transformers`-style
  transformers. The latter seem likely to lead to some performance
  issues, but I don't think there's any way around that. There
  are still a number of missing instances.

* Simplify a little code.

* Add custom `*>` implementations to make it act more like the
  default `>>` than the default `*>`. This often compiles better
  for monads like these.