### PR TITLE
Add benchmark for RWST and add cabal benchmark section

### DIFF
--- a/mtl-c.cabal
+++ b/mtl-c.cabal
@@ -23,3 +23,17 @@ library
       , Control.Monad.RWS.CPS
   -- other-modules:
   build-depends:       base ==4.*, mtl ==2.*, transformers
+
+
+benchmark benchmarks
+    Default-Language: Haskell2010
+    Type:             exitcode-stdio-1.0
+    HS-Source-Dirs:   benchmark
+    Main-Is:          benchmark.hs
+    GHC-Options:     -O2 -Wall -rtsopts -fno-warn-unused-do-bind
+
+    Build-Depends:
+        base         >= 4       && < 5  ,
+        criterion    >= 0.6.2.1 && < 1.2,
+        mtl          >= 2.0     && < 3.0,
+        mtl-c


### PR DESCRIPTION
Adds benchmarks for the RWST implementation. Results for those curious are:

```
benchmarking RWS/CPS
time                 7.105 μs   (7.024 μs .. 7.193 μs)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 7.219 μs   (7.129 μs .. 7.316 μs)
std dev              328.5 ns   (264.4 ns .. 442.3 ns)
variance introduced by outliers: 57% (severely inflated)
             
benchmarking RWS/Strict
time                 375.9 μs   (370.0 μs .. 383.2 μs)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 378.5 μs   (372.5 μs .. 385.3 μs)
std dev              21.33 μs   (17.28 μs .. 26.87 μs)
variance introduced by outliers: 52% (severely inflated)
             
benchmarking RWS/Lazy
time                 1.134 ms   (1.108 ms .. 1.159 ms)
                     0.996 R²   (0.994 R² .. 0.997 R²)
mean                 1.149 ms   (1.129 ms .. 1.169 ms)
std dev              67.18 μs   (56.78 μs .. 86.25 μs)
variance introduced by outliers: 47% (moderately inflated)
```